### PR TITLE
Crash when app goes to background without overlay permission

### DIFF
--- a/takt/src/main/java/jp/wasabeef/takt/Takt.java
+++ b/takt/src/main/java/jp/wasabeef/takt/Takt.java
@@ -136,7 +136,7 @@ public class Takt  {
     public void stop() {
       metronome.stop();
 
-      if (show && stageView != null) {
+      if (show && isPlaying) {
         wm.removeView(stageView);
         isPlaying = false;
       }


### PR DESCRIPTION
## Issue
Crash when app goes to background without overlay permission

## What is the value of this and can you measure success?
fixed crash


