### PR TITLE
added no-op artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.6.0-alpha05'
+    classpath 'com.android.tools.build:gradle:3.6.1'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -30,5 +30,5 @@ android {
 dependencies {
   implementation project(':takt')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-  implementation "androidx.appcompat:appcompat:1.1.0-rc01"
+  implementation "androidx.appcompat:appcompat:1.1.0"
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -29,6 +29,7 @@ android {
 
 dependencies {
   implementation project(':takt')
+  /*implementation project(':takt-no-op')*/
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   implementation "androidx.appcompat:appcompat:1.1.0"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 09 11:49:23 JST 2019
+#Sat Mar 07 13:31:32 IRST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':example', ':takt'
+include ':example', ':takt', ':takt-no-op'

--- a/takt-no-op/build.gradle
+++ b/takt-no-op/build.gradle
@@ -1,0 +1,33 @@
+apply plugin: 'com.android.library'
+
+android {
+  compileSdkVersion COMPILE_SDK_VERSION as int
+
+  defaultConfig {
+    minSdkVersion MIN_SDK_VERSION as int
+    targetSdkVersion TARGET_SDK_VERSION as int
+  }
+}
+
+ext {
+  bintrayRepo = 'maven'
+  bintrayName = 'takt'
+  bintrayUserOrg = 'wasabeef'
+  publishedGroupId = 'jp.wasabeef'
+  libraryName = 'takt'
+  artifact = 'takt'
+  libraryDescription = 'Android libraries for measuring the FPS'
+  siteUrl = 'https://github.com/wasabeef/Takt'
+  gitUrl = 'https://github.com/wasabeef/Takt.git'
+  issueUrl = 'https://github.com/wasabeef/Takt/issues'
+  libraryVersion = VERSION_NAME
+  developerId = 'wasabeef'
+  developerName = 'Wasabeef'
+  developerEmail = 'dadadada.chop@gmail.com'
+  licenseName = 'The Apache Software License, Version 2.0'
+  licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+  allLicenses = ["Apache-2.0"]
+}
+
+apply from: 'https://gist.githubusercontent.com/wasabeef/cf14805bee509baf7461974582f17d26/raw/bintray-v1.gradle'
+apply from: 'https://gist.githubusercontent.com/wasabeef/cf14805bee509baf7461974582f17d26/raw/install-v1.gradle'

--- a/takt-no-op/src/main/AndroidManifest.xml
+++ b/takt-no-op/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="jp.wasabeef.takt" />

--- a/takt-no-op/src/main/java/jp/wasabeef/takt/Audience.java
+++ b/takt-no-op/src/main/java/jp/wasabeef/takt/Audience.java
@@ -1,0 +1,21 @@
+package jp.wasabeef.takt;
+
+/**
+ * Copyright (C) 2019 Wasabeef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public interface Audience {
+  void heartbeat(double fps);
+}

--- a/takt-no-op/src/main/java/jp/wasabeef/takt/LifecycleListener.java
+++ b/takt-no-op/src/main/java/jp/wasabeef/takt/LifecycleListener.java
@@ -1,0 +1,39 @@
+package jp.wasabeef.takt;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+
+/**
+ * @author aleien on 21.10.18.
+ */
+public class LifecycleListener implements Application.ActivityLifecycleCallbacks {
+
+    public LifecycleListener(LifecycleCallbackListener listener) { }
+
+    public interface LifecycleCallbackListener {
+        void onAppForeground();
+        void onAppBackground();
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {}
+
+    @Override
+    public void onActivityStopped(Activity activity) {}
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {}
+
+    @Override
+    public void onActivityResumed(Activity activity) {}
+
+    @Override
+    public void onActivityPaused(Activity activity) {}
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {}
+}

--- a/takt-no-op/src/main/java/jp/wasabeef/takt/Seat.java
+++ b/takt-no-op/src/main/java/jp/wasabeef/takt/Seat.java
@@ -1,0 +1,43 @@
+package jp.wasabeef.takt;
+
+import android.view.Gravity;
+
+/**
+ * Copyright (C) 2019 Wasabeef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public enum Seat {
+  TOP_RIGHT(Gravity.TOP | Gravity.END),
+  TOP_LEFT(Gravity.TOP | Gravity.START),
+  TOP_CENTER(Gravity.TOP | Gravity.CENTER_HORIZONTAL),
+
+  RIGHT_CENTER(Gravity.END | Gravity.CENTER_VERTICAL),
+  LEFT_CENTER(Gravity.START | Gravity.CENTER_VERTICAL),
+  CENTER(Gravity.CENTER),
+
+  BOTTOM_RIGHT(Gravity.BOTTOM | Gravity.END),
+  BOTTOM_LEFT(Gravity.BOTTOM | Gravity.START),
+  BOTTOM_CENTER(Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL);
+
+  private int gravity;
+
+  Seat(int gravity) {
+    this.gravity = gravity;
+  }
+
+  public int getGravity() {
+    return gravity;
+  }
+}

--- a/takt-no-op/src/main/java/jp/wasabeef/takt/Takt.java
+++ b/takt-no-op/src/main/java/jp/wasabeef/takt/Takt.java
@@ -1,0 +1,96 @@
+package jp.wasabeef.takt;
+
+import android.app.Application;
+
+/**
+ * Copyright (C) 2019 Wasabeef
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class Takt {
+
+    private final static Program program = new Program();
+
+    private Takt() {
+    }
+
+    public static Program stock(Application application) {
+        return program.prepare(application);
+    }
+
+    public static void play() {
+    }
+
+    public static void finish() {
+    }
+
+    public static class Program implements LifecycleListener.LifecycleCallbackListener {
+        public Program() {
+        }
+
+        private Program prepare(Application application) {
+            return this;
+        }
+
+        @Override
+        public void onAppForeground() {
+        }
+
+        @Override
+        public void onAppBackground() {
+        }
+
+        public void play() {
+        }
+
+        public void stop() {
+        }
+
+        public Program color(int color) {
+            return this;
+        }
+
+        public Program size(float size) {
+            return this;
+        }
+
+        public Program useCustomControl() {
+            return this;
+        }
+
+        public Program alpha(float alpha) {
+            return this;
+        }
+
+        public Program interval(int ms) {
+            return this;
+        }
+
+        public Program listener(Audience audience) {
+            return this;
+        }
+
+        public Program hide() {
+            return this;
+        }
+
+        public Program seat(Seat seat) {
+            return this;
+        }
+
+        public Program showOverlaySetting(boolean enable) {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?
`no-op` artifact was added.

## What is the value of this and can you measure success?
As we know this library is for staging/debug mode. also requires some permission to draw on apps that are not reasonable to be on production.
This pull-request will make safer to use this library and can handle it from gradle implementation commands.
such as : 
```
productionImplemetation 'jp.wasabeef:takt-no-op:2.0.1'
stagingImplemetation 'jp.wasabeef:takt:2.0.1'
```

## Screenshots
No need.


## Note
I'm not familiar with bintray configs to release this artifact. and just copy and paste build.gradle from the original module. You should edit it.
 
